### PR TITLE
Oprava odkazů do repa

### DIFF
--- a/_includes/footer.html
+++ b/_includes/footer.html
@@ -10,9 +10,9 @@
         </span>
         <span class="footer-right">
             &copy; 2020 Fakta o klimatu, z. ú.<br/>
-            Poslední změna: <a class="no-ext-link-icon" href="{{ site.repo-url }}/commit/{{ site.git.commit_hash }}"
+            Poslední změna: <a class="no-ext-link-icon" href="https://github.com/faktaoklimatu/web/commit/{{ site.git.commit_hash }}"
             title="commit {{ site.git.commit_hash_short }}">{{ site.git.commit_date }}</a><br/>
-            GitHub: <a class="no-ext-link-icon" href="{{ site.repo-url }}">faktaoklimatu/web</a>
+            GitHub: <a class="no-ext-link-icon" href="https://github.com/faktaoklimatu/web/">faktaoklimatu/web</a>
         </span>
     </div>
 </footer>


### PR DESCRIPTION
Patička odkazovala na proměnnou site.repo-url, která ale AFAIK není nikde nastavená, a tak odkazy nefungovaly. Dal jsem tam natvrdo URL repa, to chytřejší řešení s proměnnou nastavenou jinde zatím nevidím jako nutné, když jde jen o dvě použití na stejném místě.