### PR TITLE
Instrukce pro vývoj s kontejnery

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -1,0 +1,20 @@
+FROM ubuntu:bionic
+
+LABEL name="Fakta o klimatu" \
+      summary="Jekyll deployment with Inkscape and pdf2svg for the faktaoklimatu.cz website" \
+      usage="docker run --name faktaweb -p 4000:4000 -v $PWD:/srv/jekyll -it faktaoklimatu"
+
+RUN apt-get update && \
+    apt-get install --assume-yes --no-install-suggests --no-install-recommends \
+        build-essential git-core inkscape pdf2svg ruby-bundler ruby-dev zlib1g-dev
+
+# Install gems during build of the image so that we can leverage the cache.
+COPY Gemfile* /tmp
+WORKDIR /tmp
+RUN bundle install
+
+EXPOSE 4000
+VOLUME /srv/jekyll
+WORKDIR /srv/jekyll
+
+CMD ["make", "-j4", "local"]

--- a/Gemfile
+++ b/Gemfile
@@ -3,10 +3,10 @@ source 'https://rubygems.org'
 gem 'ffi-icu'
 gem 'html-proofer'
 gem 'jekyll'
-gem 'jekyll-redirect-from'
-gem 'nokogumbo'
 gem 'jekyll-last-modified-at'
+gem 'jekyll-redirect-from'
 gem 'jekyll-sitemap'
+gem 'nokogumbo'
 
 # The plugin in the gem repository is ccurrently not maintained.
 # Temporarity provided locally.

--- a/README.md
+++ b/README.md
@@ -1,6 +1,6 @@
 # O projektu Fakta o klimatu
 
-Shromažďujeme data o klimatu a klimatické změně, která poskytují vědecké instituce (ČHMÚ, NASA, Eurostat a jiné) a zpracováváme z nich grafy a infografiky pro další použití.
+Shromažďujeme data o klimatu a klimatické změně, která poskytují vědecké instituce (ČHMÚ, NASA, Eurostat a jiné) a zpracováváme z nich grafy, infografiky a přístupné datasety pro další použití.
 
 Jsme studenti, doktorandi, akademici nebo IT profesionálové. Sami jsme si zkusili vyhledat data o teplotě či emisích, najít určité informace v mnohasetstránkových zprávách IPCC nebo původních článcích. Jde to, ale zabere to hodně času. Musíte umět dobře anglicky a musíte si dohledávat spoustu souvislostí. Běžný novinář nebo politik (ani bězný Čech) většinou nemá tolik trpělivosti nebo dostatečnou úroveň angličtiny a tak si data nevyhledá. Rozhodli jsme se proto, že tu práci, kterou jsme s hledáním dat sami měli, ostatním ušetříme - zpracujeme infografiky, dáme odkazy na původní data i naše zpracované datasety na jedno místo a doplníme základní souvislosti. A dáme je k dispozici všem, pro koho budou užitečné. Doufáme, že se postupně tyto informace dostanou ke všem, kterých se změny klimatu týkají. Tedy ke všem.
 
@@ -23,13 +23,13 @@ Co se týče formátu, inspirujte se u existujících, dodržte hlavičku. Váho
 
 ### Vytvoření stránky grafiky
 
-Zobrazují se v sekcích na úvodní stránce, každá infografika musí mít svoji stránku samostatnou stránku v `_infografiky/`.
-Názvy souborů musí mít vždy formát `<SLUG>.md`. Soubory jsou pro přehlednost ukládány v složkách podle primárního tagu.
+Zobrazují se v sekcích na úvodní stránce, každá infografika musí mít svoji stránku samostatnou stránku ve složce `_infografiky/`.
+Názvy souborů musí mít vždy formát `<SLUG>.md`. Soubory jsou pro přehlednost ukládány ve složkách podle primárního tagu.
 
-Co se týče formátu, inspirujte se u existujících, dodržte hlavičku. Váhou určíte pořadí v rámci grafik v jedné sekci.
+Co se týče formátu, inspirujte se u existujících a dodržujte hlavičku. Váhou určíte pořadí v rámci grafik v jedné sekci – stránky s nižší váhou se zobrazí před stránkami s váhou vyšší.
 Nezbytné pro správné zobrazení jsou tagy, např. `tags: [ teploty ]`. Zde se vyskytují tagy, podle kterých se infografiky vybírají do sekcí na úvodni stránce.
 
-Obrázky jednotlivých grafik (pouze SVG) a data (aktuálně pouze XLSX) nahrávejte do stejé složky jako infografiky se stejným názvem jako je souor infografiky.
+Obrázky jednotlivých grafik (pouze PDF) nahrávejte do stejé složky jako infografiky se stejným názvem jako je souor infografiky.
 
 ## Změna e-mailové adresy pro kontaktní formulář
 
@@ -51,6 +51,6 @@ Po provedení všech změn nezapomeňte pushnout, ideálně do samostatné větv
 
 ## Jak nasadit novou verzi
 
-Na webu https://faktaoklimatu.cz (resp. https://mukrop.github.io/faktaoklimatu/) se nasadí automaticky každá verze, která je v hlavní větvi (`master`) tohoto repozitáře na GitHubu.
+Na webu https://faktaoklimatu.cz se nasadí automaticky každá verze, která je v hlavní větvi (`master`) tohoto repozitáře na GitHubu.
 
 V případě potíží zůstane k dispozici stará verze a důvod selhání bude potřeba získat skrze správce, tím je vlastník tohoto repozitáře.

--- a/README.md
+++ b/README.md
@@ -10,30 +10,18 @@ Jsme studenti, doktorandi, akademici nebo IT profesionálové. Sami jsme si zkus
 
 Nahrávání obsahu vyžaduje drobné technické zkušenosti, schopnost pracovat s verzovacím systémem Git a dodržení tohoto návodu.
 
-Obsah je členěn do sekcí, ke kterým je jedna či více info grafik, které odkazují vždy jeden obrázek.
+## Titulní stránka
 
-## Jednotlivé sekce
-
-### Vytvoření sekce
-
-Jednotlivé sekce se zobrazují na úvodní stránce a vytváří se v `_sekce/`. Názvy souborů musí mít vždy formát
-`<SLUG>.md`, kde SLUG je nějaké zkrácené smysluplné jméno používající jen znaky anglické abecedy, číslice a znaky jako `-` a `_`.
-
-Co se týče formátu, inspirujte se u existujících, dodržte hlavičku. Váhou určete pořadí na úvodní stránce.
+Obsah je členěn do sekcí, ke kterým je jedna či více info grafik, které odkazují vždy jeden obrázek. Po sekcích následuje seznam studií, datasetů a dalších stránek. Obsah sekcí odpovídá tématům (`tags-topics`) definovaných u jednotlivých objektů. Metadata těchto sekcí (název, popis, ...) jsou uloženy v `_data/tags.yml`. Obsah ostatních částí (studie, datasety, stránky) je definován v souboru titulní stránky (`_stranky/index.md`)
 
 ### Vytvoření stránky grafiky
 
 Zobrazují se v sekcích na úvodní stránce, každá infografika musí mít svoji stránku samostatnou stránku ve složce `_infografiky/`.
-Názvy souborů musí mít vždy formát `<SLUG>.md`. Soubory jsou pro přehlednost ukládány ve složkách podle primárního tagu.
+Názvy souborů musí mít vždy formát `<SLUG>.md`. Soubory jsou pro přehlednost ukládány ve složkách podle primárního tématu.
 
-Co se týče formátu, inspirujte se u existujících a dodržujte hlavičku. Váhou určíte pořadí v rámci grafik v jedné sekci – stránky s nižší váhou se zobrazí před stránkami s váhou vyšší.
-Nezbytné pro správné zobrazení jsou tagy, např. `tags: [ teploty ]`. Zde se vyskytují tagy, podle kterých se infografiky vybírají do sekcí na úvodni stránce.
+Co se týče formátu, inspirujte se u existujících a dodržujte hlavičku. Váhou určíte pořadí v rámci grafik v jedné sekci – stránky s nižší váhou se zobrazí před stránkami s váhou vyšší. Nezbytné pro správné zobrazení jsou témata (`tags-topics`) a oblasti (`tags-scope`). Zde se vyskytují tagy, podle kterých se infografiky vybírají do sekcí na úvodní stránce.
 
-Obrázky jednotlivých grafik (pouze PDF) nahrávejte do stejé složky jako infografiky se stejným názvem jako je souor infografiky.
-
-## Změna e-mailové adresy pro kontaktní formulář
-
-V souboru `_config.yml` nakonfigurujte pomocí hodnoty `contact`.
+Obrázky jednotlivých grafik (pouze PDF) nahrávejte do stejné složky jako infografiky se stejným názvem jako je soubor infografiky.
 
 ## Jak vyvíjet lokálně
 

--- a/README.md
+++ b/README.md
@@ -37,15 +37,50 @@ V souboru `_config.yml` nakonfigurujte pomocí hodnoty `contact`.
 
 ## Jak vyvíjet lokálně
 
-Stránku lze vyvíjet i na svém osobním stroji a experimentovat tak například s novým typem obsahu, stylem stránky...
-Je k tomu potřeba si připravit potřebné nástroje, doporučujeme postupovat podle tohoto 
-[návodu](https://help.github.com/en/articles/setting-up-your-github-pages-site-locally-with-jekyll) (v případě Ubuntu 
-18.04 nutno nejdříve nainstalovat balíčky `libpng-dev zlib1g-dev build-essential dh-autoreconf`). Dále je potřeba 
-mít nainstalovaný vektorový editor [Inkscape](https://inkscape.org/) a utilitu `pdf2svg`,
-které se používají na konverzi infografik.
+_Fakta o klimatu_ lze vyvíjet a testovat i lokálně na vlastním stroji. Můžete tak okamžitě vidět, jak bude například nová infografika, stránka datasetu nebo studie vypadat na živém webu. Zároveň lze experimentovat například s novým typem obsahu, stylem stránek atd.
 
-Poté již stačí v kořenové složce projektu spustit příkaz `make local`, který sestaví, co je potřeba, zpřístupní web na adrese
-http://127.0.0.1:4000 a následně bude monitorovat soubory a v případě jejich změny automaticky sestaví novou verzi stránky.
+Aktuálně podporujeme dva způsoby lokálního vývoje: pomocí kontejnerů (preferovaný způsob), nebo ruční instalací nutných balíčků. Oba způsoby jsme prozatím ozkoušeli a fungují pouze na populárních linuxových distribucích (Fedora, Ubuntu atd.).
+
+### Kontejnery
+
+Kontejnery umožňují oddělit programy nutné pro sestavení a spuštění webu od zbytku vašeho operačního systému. Zároveň vytvoří konzistentní prostředí, které je téměř totožné s tím, ve kterém se sestavuje živý, publikovaný web.
+
+Následující instrukce předpokládají, že pracujete na distribuci Fedora, ačkoliv pro ostatní distribuce by měly fungovat též, s minimálními změnami. Pro správu kontejnerů používáme balíček [Podman](https://podman.io), který je na Fedoře předinstalovaný, ale použití s [Dockerem](https://www.docker.com/) je téměř totožné (viz níže).
+
+Jedinou další prerekvizitou je program Make, který není v základní výbavě většiny distribucí. Na Fedoře jej nainstalujete jednoduše pomocí správce balíčků:
+```bash
+sudo dnf install -y make
+```
+
+Prvním krokem je získání zdrojového kódu webu. Zadáním následujících příkazů do terminálu jej stáhnete z našeho GitHubového projektu pomocí Gitu do adresáře `faktaoklimatu`:
+```bash
+git clone https://github.com/faktaoklimatu/web.git faktaoklimatu
+cd faktaoklimatu
+```
+
+Aby měl kontejner ke zdroji přístup, je potřeba upravit bezpečnostní kontext celého adresáře. (Pokud vaše distribuce nepoužívá SELinux, tento krok přeskočte.) V terminálu v adresáři se zdrojovým kódem spusťte následující příkaz:
+```bash
+sudo chcon -Rt svirt_sandbox_file_t .
+```
+
+Následně stačí v terminálu zadat
+```bash
+make container
+```
+
+Při prvním spuštění tento příkaz stáhne a připraví software potřebný pro vývoj webu. To může chvíli trvat, v závislosti na rychlosti připojení, většinou do patnácti minut. (Další spuštění jsou už rychlejší.) Následně se kontejner spustí, sestaví web ze zdrojových kódů a spustí webový server.
+
+Jakmile je vše připraveno, objeví se hláška `Server running... press ctrl-c to stop.`. Vygenerovaný web je po dobu běhu kontejneru přístupný na adrese <http://localhost:4000/>. Změny, které provedete například v doprovodných textech infografik nebo na jiných stránkách, se rychle promítnou i zde.
+
+Kontejner zastavíte stisknutím <kbd>Ctrl</kbd>+<kbd>C</kbd>. Znovu jej spustíte opět příkazem `make container`. Při dalších spuštěních se automaticky provádí už jen nezbytné kroky (např. generování obrázků nových infografik nebo generování nových HTML stránek).
+
+**Poznámka:** Pokud přidáváte novou stránku, např. novou infografiku, je potřeba kontejner zastavit a znovu spustit, aby se vygenerovaly všechny potřebné soubory. Pokud pouze upravujete texty, není třeba kontejner restartovat.
+
+### Ruční instalace
+
+Je k tomu potřeba si připravit potřebné nástroje, doporučujeme postupovat podle tohoto [návodu](https://help.github.com/en/articles/setting-up-your-github-pages-site-locally-with-jekyll) (v případě Ubuntu 18.04 nutno nejdříve nainstalovat balíčky `build-essential libpng-dev ruby-dev zlib1g-dev`). Dále je potřeba mít nainstalovaný vektorový editor [Inkscape](https://inkscape.org/) a utilitu `pdf2svg`, které se používají na konverzi infografik.
+
+Poté již stačí v kořenové složce projektu spustit příkaz `make local`, který sestaví, co je potřeba, zpřístupní web na adrese <http://localhost:4000> a následně bude monitorovat soubory a v případě jejich změny automaticky sestaví novou verzi stránky.
 
 Po provedení všech změn nezapomeňte pushnout, ideálně do samostatné větve u které následně požádáte o *Pull Request*, aby existovala možnost práci zkontrolovat.
 

--- a/_config.yml
+++ b/_config.yml
@@ -7,13 +7,18 @@ author: faktaoklimatu.cz
 description: Shromažďujeme data o klimatu a klimatické změně, která poskytují vědecké instituce a zpracováváme z nich grafy a infografiky pro další použití.
 keywords: klima, změna klimatu, infografiky
 
-# Build settings
 include: [ ".well-known" ]
-exclude: [ "Gemfile", "Gemfile.lock", "Makefile"    # Build settings
-         , "README.md", "utils"                     # Development files
-         , "_infografiky/*/*.pdf"                   # Original infographics (build moves them to assets)
-         , "_studie/*.jpg", "_studie/*.png"         # Study images
-         ]
+exclude:
+    - README.md
+    - AUTHORS.md           # Authors file
+    - Gemfile              # Build settings
+    - Gemfile.lock         # Build settings
+    - Makefile             # Build settings
+    - utils                # Development files
+    - Dockerfile           # Containerization
+    - _infografiky/*/*.pdf # Original infographics (build moves them to assets)
+    - _studie/*.jpg        # Study images
+    - _studie/*.png        # Study images
 collections:
     infografiky:
         output: true

--- a/_infografiky/emise/emise-cr.md
+++ b/_infografiky/emise/emise-cr.md
@@ -6,7 +6,7 @@ redirect_from: "/emise-cr"
 weight:     98
 tags-scopes: [ cr ]
 tags-topics: [ emise ]
-caption:    "Rozložení celkových emisí skleníkových plynů (v tunách CO<sub>2</sub> ekvivalentu) v ČR za jeden rok v jednotlivých sektorech lidské činnosti. Roční objem emisí České republiky je 131,31 mil. tun (údaj z roku 2016). V přepočtu na obyvatele to je 12,44 tCO<sub>2</sub>eq/obyvatele."
+caption:    "Rozložení celkových emisí skleníkových plynů (v tunách CO<sub>2</sub> ekvivalentu) v ČR za jeden rok v jednotlivých sektorech lidské činnosti. Roční objem emisí České republiky je 131,31 mil. tun (údaj z roku 2016). V přepočtu na obyvatele to je 12,44 t CO<sub>2</sub>eq/obyvatele."
 dataset:    "emise-cr"
 ---
 

--- a/_plugins/glyph-replacement.rb
+++ b/_plugins/glyph-replacement.rb
@@ -11,9 +11,9 @@ end
 def replace!(content)
   # One-letter conjunctions and prepositions should not be left hanging.
   content.gsub!(/ ([aikosuvz]) /i, ' \1&nbsp;')
-  # Thin sapces before percent sign and before groups of digits.
-  content.gsub!(/(?<=\d) (%|\d{3})/, '&#8239;\1')
+  # Thin spaces before percent sign, permille sign and before groups of digits.
+  content.gsub!(/(?<=\d) (%|‰|\d{3})/, '&#8239;\1')
   # Non-breaking spaces before units.
-  content.gsub!(/(?<=\d) (°C|ppm|kg|mil\.|tCO)/, '&nbsp;\1')
-  content.gsub!(/(?<=\d) ([kMGT]?Wh?)/, '&nbsp;\1')
+  content.gsub!(/(?<=\d) (°C|ppm|kg|mil\.)/, '&nbsp;\1')
+  content.gsub!(/(?<=\d) ([kMGT]?(?:t CO|Wh?))/, '&nbsp;\1')
 end

--- a/utils/convert-infographic.sh
+++ b/utils/convert-infographic.sh
@@ -17,7 +17,7 @@ set -e
 # keep track of the last executed command
 trap 'last_command=$current_command; current_command=$BASH_COMMAND' DEBUG
 # echo an error message before exiting
-trap 'echo "\"${last_command}\" command filed with exit code $?."' EXIT
+trap 'echo "\"${last_command}\" command exited with code $?."' EXIT
 
 # Set names
 SRC_FILE_PDF=$1


### PR DESCRIPTION
* Přidán `Dockerfile` pro obraz kontejneru, který by měl být téměř totožný s deploymentem na Travisu.
* Upraveny a rozšíření instrukce pro lokální vývoj v `README.md`.

(Plus drobné úpravy tu a tam, neboť se mi nechce pro každou vytvářet zvláštní PR.)

Nahrazuje #410.