### PR TITLE
Oprava nefunkčních odkazů

### DIFF
--- a/_data/news.yml
+++ b/_data/news.yml
@@ -122,11 +122,11 @@
   summary: "V nové sekci [Další zdroje a odkazy](/zdroje) uvádíme rozcestník odkazů na stránky vybraných výzkumných institucí, repozitářů dat, projektů vizualizující data a další. Ve [Slovníku pojmů](/slovnik) uvádíme pro přehlednost a vyšší srozumitelnost stručný přehled nejčastěji používaných hesel a zkratek s krátkým vysvětlením či komentářem."
 
 - date: 2019-09-03
-  summary: "Rozšíření core týmu o Oldu Sklenáře, Toma Protivínského a Jana Krčála, aktualizace [sekce O nás](/#creators), publikování kompletního seznamu na projektu se podílejících lidí ([AUTHORS.md](https://github.com/mukrop/faktaoklimatu/blob/master/AUTHORS.md)), u některých infografik přidáno více primárních zdrojů dat."
+  summary: "Rozšíření core týmu o Oldu Sklenáře, Toma Protivínského a Jana Krčála, aktualizace [sekce O nás](/#creators), publikování [kompletního seznamu](https://github.com/faktaoklimatu/web/blob/master/CONTRIBUTORS.md#readme) na projektu se podílejících lidí, u některých infografik přidáno více primárních zdrojů dat."
 
 - date: 2019-08-23
   title: "Vznik sekce Studie a tři nové infografiky"
-  summary: "V rámci zvyšování kvality a důvěryhodnosti jsme zapracovali první tři významné studie, na které se odkazujeme, a/nebo které jsou pro doplňující pochopení a vzhled do tématu změn klimatu důležité ([sekce Studie](/#/sekce/studie)). Dále jsme rozšířili paletu infografik o [Emise skleníkových plynů EU](/infografiky/emise-eu), [Pořadí států EU podle emisí skleníkových plynů](/infografiky/emise-eu-poradi), a [Vývoj koncentrace CO<sub>2</sub> v historii](/infografiky/koncentrace-co2). Tímto také vzniká problém se započtením emisí letecké dopravy – dataset z Eurostatu umožňuje započítání letecké dopravy (i když trochu problematické) a my díky tomu začínáme řešit, pro jaký standard se rozhodneme. Problém se podařilo uzavřít 12. října 2019: budeme leteckou dopravu zobrazovat, i když je tam problematická atribuce."
+  summary: "V rámci zvyšování kvality a důvěryhodnosti jsme zapracovali první tři významné studie, na které se odkazujeme, a/nebo které jsou pro doplňující pochopení a vzhled do tématu změn klimatu důležité ([sekce Studie](/#studie)). Dále jsme rozšířili paletu infografik o [Emise skleníkových plynů EU](/infografiky/emise-eu), [Pořadí států EU podle emisí skleníkových plynů](/infografiky/emise-eu-poradi), a [Vývoj koncentrace CO<sub>2</sub> v historii](/infografiky/koncentrace-co2). Tímto také vzniká problém se započtením emisí letecké dopravy – dataset z Eurostatu umožňuje započítání letecké dopravy (i když trochu problematické) a my díky tomu začínáme řešit, pro jaký standard se rozhodneme. Problém se podařilo uzavřít 12. října 2019: budeme leteckou dopravu zobrazovat, i když je tam problematická atribuce."
 
 - date: 2019-08-05
   summary: "Rozhovor v rádiu Wave – Ondráš Přibyla a Marek Lahoda představují projekt v [rozhovoru pro rádio Wave](https://wave.rozhlas.cz/projekt-fakta-o-klimatu-v-mediich-maji-popiraci-klimatickych-zmen-vetsi-prostor-8033240): _'My bychom chtěli nejdřív pokrýt něco, co by se dalo považovat za základní znalosti. Grafy, které bychom chtěli publikovat v tomto roce, by měly pokrýt něco 'jako maturitu z klimatických změn'. To znamená, chceme, aby lidi věděli, že se Česká republika oteplila o dva stupně od roku 1960, zhruba jaké jsou emise v Česku a ve světě a proč je vůbec důležité to řešit. Ono se zdá, že změna o jeden a půl stupně Celsia je malá, ale je potřeba vysvětlit, co to znamená z hlediska bodů zlomu, ke kterým se blížíme, a z hlediska celého klimatického systému planety...'_"
@@ -139,7 +139,7 @@
 
 - date: 2019-07-23
   title: "faktaoklimatu.cz online!"
-  summary: "Zveřejněna první verze webu obsahující základní set infografik: 3&times; [Vývoj teplot a koncentrací skleníkových plynů](/#/sekce/teploty), 3&times; [Emise skleníkových plynů](/#/sekce/emise) a úvodní slovo."
+  summary: "Zveřejněna první verze webu obsahující základní set infografik: 3&times; _Vývoj teplot a koncentrací skleníkových plynů_, 3&times; _Emise skleníkových plynů_ a úvodní slovo."
 
 - date: 2019-06-26
   summary: "Třetí klimatický hackathon – pokračující přípravy na zveřejnění webu, sepisování a ladění textů, rozšiřování infografik, založen e-mail [info@faktaoklimatu.cz](mailto:info@faktaoklimatu.cz)."

--- a/_infografiky/emise/emise-eu.md
+++ b/_infografiky/emise/emise-eu.md
@@ -24,10 +24,11 @@ dataset:    "emise-eu"
 
 ## Zajímavosti a komentáře k ročním emisím na obyvatele
 
-* Lucembursko, které je v přepočtu na obyvatele na prvním místě, má [dle platformy Votum Klima](https://today.rtl.lu/news/luxembourg/a/1184731.html) tak vysoké emise kvůli nafto-benzínovému turismu ([5x vyšší než průměr EU](https://docs.google.com/spreadsheets/d/1ldy3l-W0HDG1cHK393_rQC5pGXIWbVw94Dh3ie4aEI8/edit#gid=1336176067&range=R24))
-* Estonsko, na druhém místě, má velmi vysoký podíl špinavé energetiky ([4,5x vyšší než průměr EU](https://docs.google.com/spreadsheets/d/1ldy3l-W0HDG1cHK393_rQC5pGXIWbVw94Dh3ie4aEI8/edit#gid=1336176067&range=H22))
-* Irsko, na třetím místě, má velmi vysoký podíl zemědělské produkce ([skoro 5x vyšší než průměr EU](https://docs.google.com/spreadsheets/d/1ldy3l-W0HDG1cHK393_rQC5pGXIWbVw94Dh3ie4aEI8/edit#gid=1336176067&range=I27))
-* Česká republika, na čtvrtém místě, má velmi vysoký podíl špinavé energetiky ([2x vyšší než průměr EU](https://docs.google.com/spreadsheets/d/1ldy3l-W0HDG1cHK393_rQC5pGXIWbVw94Dh3ie4aEI8/edit#gid=1336176067&range=E22), zejména vlivem hnědouhelných elektráren) - viz naše  [související infografika zobrazující podíl jednotlivých činností na celkové emise CO<sub>2</sub>](/infografiky/emise-cr-detail).
+* Lucembursko, které je v přepočtu na obyvatele na prvním místě, má [dle platformy Votum Klima](https://today.rtl.lu/news/luxembourg/a/1184731.html) tak vysoké emise kvůli nafto-benzínovému turismu (5x vyšší než průměr EU)
+* Estonsko, na druhém místě, má velmi vysoký podíl špinavé energetiky (4,5x vyšší než průměr EU)
+* Irsko, na třetím místě, má velmi vysoký podíl zemědělské produkce (skoro 5x vyšší než průměr EU)
+* Česká republika, na čtvrtém místě, má velmi vysoký podíl špinavé energetiky (2x vyšší než průměr EU, zejména vlivem hnědouhelných elektráren) - viz naše  [související infografika](/infografiky/emise-cr-detail).
+* Všechny zmíněné údaje najdete v našem podrobném datasetu v sekci "Emise na obyvatele podle základních kategorií".
 
 ## Poznámky k datům o emisích
 * Emisní inventura poskytovaná Eurostatem využívá formát a strukturu dat CRF (common reporting format), veškerá metodika k výpočtům a reportingu je na stránkách národního programu inventarizace emisí ([NGGIP - national greenhouse gas inventory programme](https://www.ipcc-nggip.iges.or.jp/)) a je závazná pro všechny státy [UNFCCC](https://cs.wikipedia.org/wiki/R%C3%A1mcov%C3%A1_%C3%BAmluva_OSN_o_zm%C4%9Bn%C4%9B_klimatu).

--- a/_studie/2018_energetika-cr-bez-uhli.md
+++ b/_studie/2018_energetika-cr-bez-uhli.md
@@ -11,8 +11,8 @@ study-title:        "Czech power grid without electricity from coal by 2030"
 study-author:       "Peter-Philipp Schierhorn, M.Sc. et al."
 study-institution:  "Energynautics"
 study-year:         2018
-study-url:          "https://glopolis.org/_publications/jak-muze-ceska-sit-zvladnout-utlum-uhelnych-elektraren-a-nastup-obnovitelnych-zdroju"
-study-pdf:          "http://glopolis.org/wp-content/uploads/Czech-Grid-Without-Coal-By-2030_fin.pdf"
+study-url:          "https://web.archive.org/web/20200420141655/https://glopolis.org/_publications/jak-muze-ceska-sit-zvladnout-utlum-uhelnych-elektraren-a-nastup-obnovitelnych-zdroju"
+study-pdf:          "https://web.archive.org/web/20190904122943if_/http://glopolis.org/wp-content/uploads/Czech-Grid-Without-Coal-By-2030_fin.pdf"
 summary: |
     * Studie dochází k závěru, že __stabilita sítě není zásadní překážkou pro přechod české energetiky od uhlí k obnovitelným zdrojům.__
     * Bezpečnost dodávek bude při uvažovaném scénáři možné zajistit i pro následující události/varianty dalšího vývoje:
@@ -25,13 +25,13 @@ summary: |
         * Obnovitelné zdroje jsou vcelku rovnoměrně rozmístěny po území České republiky. Přenos větrné elektřiny na velké vzdálenosti, jak je známe z Velké Británie nebo Německa, zde nepředstavuje vážný problém.
         * Síť rozvádí elektřinu od několika centrálních zdrojů do poměrně vzdálených míst spotřeby. To je rozdíl ve srovnání s Velkou Británií nebo Německem, kde jsou elektrárny často postaveny v blízkostí míst s vysokou spotřebou.
         * Významný podíl výroby elektřiny z obnovitelných zdrojů pokrývají zdroje na biomasu a bioplyn, které jsou do určité míry dispečersky řiditelné.
-metadata-extra: '<a href="http://glopolis.org/wp-content/uploads/Infolist-sit-bez-uhli.pdf" id="study-link-3" class="btn btn-secondary">Infolist studie (česky)</a>'
+metadata-extra: '<a href="https://web.archive.org/web/20191231044313if_/http://glopolis.org/wp-content/uploads/Infolist-sit-bez-uhli.pdf" id="study-link-3" class="btn btn-secondary">Infolist studie (česky)</a>'
 ---
 
 ## Předpoklady a metodologie
 
 * Pro rok 2030 je uvažována čistá spotřeba na úrovni 65 TWh oproti 60,7 TWh v roce 2017. Česká republika zůstane zemí, která vyváží více elektřiny, než dováží, byť čistý export klesne na 4 TWh oproti 13 TWh v roce 2017.
-* Autoři studie podrobně modelovali chování sítě pro různé scénáře denní spotřeby v roce 2030. Vstupní údaje o rychlosti větru a slunečním záření vycházejí z konkrétních údajů pro rok 2012 (průměrný větrný a sluneční rok ve střední Evropě) v 15 minutovém rozlišení. Simulace síťových parametrů byla provedena v hodinovém rozlišení pro celý rok 2030. Modelovaný průběh výroby a spotřeby je ve studii zobrazen pro některé měsíce [formou grafů (str. 22)](http://glopolis.org/wp-content/uploads/Czech-Grid-Without-Coal-By-2030_fin.pdf#page=22).
+* Autoři studie podrobně modelovali chování sítě pro různé scénáře denní spotřeby v roce 2030. Vstupní údaje o rychlosti větru a slunečním záření vycházejí z konkrétních údajů pro rok 2012 (průměrný větrný a sluneční rok ve střední Evropě) v 15 minutovém rozlišení. Simulace síťových parametrů byla provedena v hodinovém rozlišení pro celý rok 2030. Modelovaný průběh výroby a spotřeby je ve studii zobrazen pro některé měsíce [formou grafů (str. 22)](https://web.archive.org/web/20190904122943if_/http://glopolis.org/wp-content/uploads/Czech-Grid-Without-Coal-By-2030_fin.pdf#page=22).
 * V provozu zůstanou pouze uhelné zdroje s kombinovanou výrobou tepla a elektřiny a kogenerační zdroje v průmyslových podnicích. Budou dokončeny v současné době plánované projekty rozvoje přenosové soustavy.
 
 <div class="table table-striped table-hover" markdown="1">


### PR DESCRIPTION
Opraveny odkazy na neexistující nebo přesunuté stránky.

Poslední commit, ea551d9, mění odkazy na archivované verze, protože web Glopolisu (dočasně?) nefunguje. (Máme k takovým situacím stanovený postup? Vidím, že i text ke Sternově zprávě se odkazuje na archiv.)