### PR TITLE
Oprava průhlednosti gradientů na Safari/iOS

### DIFF
--- a/assets/_scss/index.scss
+++ b/assets/_scss/index.scss
@@ -80,7 +80,7 @@ a.preview-card:hover {
 
 .more-overlay-box {
     overflow: hidden;
-    background-image: radial-gradient(white 30%, rgba(255,255,255,0.8) 60%, transparent 100%);
+    background-image: radial-gradient(white 30%, rgba(255,255,255,0.8) 60%, rgba(255,255,255,0) 100%);
     display: flex;
     justify-content: center;
     align-items: center;

--- a/assets/_scss/tags.scss
+++ b/assets/_scss/tags.scss
@@ -11,7 +11,7 @@
 }
 
 .tags-gradient-background {
-    background-image: linear-gradient(transparent, white, white);
+    background-image: linear-gradient(rgba(255,255,255,0), white 80%);
 }
 
 .tags {
@@ -23,6 +23,7 @@
     margin: 0;
     padding: 0.15rem 0.5rem;
     border-radius: 1em;
+    background-color: white;
     color: $c-grey;
     border-color: $c-grey;
 }


### PR DESCRIPTION
Safari na iOS špatně vykresluje barvu `transparent` v přechodech do bílé, viz ilustrace níže. Řešením je změna na „průhlednou bílou”, `rgba(255,255,255,0)`.

![ios-safari](https://user-images.githubusercontent.com/134321/91476491-5c0bad00-e89d-11ea-8806-9e58c1b73771.jpg)
