### PR TITLE
Zarovnání do bloku pouze u delších textů

### DIFF
--- a/assets/_scss/core_design.scss
+++ b/assets/_scss/core_design.scss
@@ -8,7 +8,6 @@ body {
     display: flex;
     min-height: 100vh;
     flex-direction: column;
-    text-align: justify;
 
     @media screen and (max-width: 768px) {
         text-align: left;
@@ -77,6 +76,10 @@ a {
 }
 
 /* Textual elements */
+
+p, li, dd {
+    text-align: justify;
+}
 
 p:last-child {
     margin-bottom: 0;


### PR DESCRIPTION
Text se zarovnává do bloku pouze u delších souvislých textů, v našem případě v odstavcích a seznamech. Nadpisy apod. zůstavají zarované na levý praporek.