### PR TITLE
Rozcestník studií transformace energetiky

### DIFF
--- a/_config.yml
+++ b/_config.yml
@@ -35,10 +35,10 @@ collections:
         permalink: /:collection/:title
     datasety:
         output: true
-        permalink: /datasety/:title
+        permalink: /:collection/:title
     rozcestniky:
         output: true
-        permalink: /rozcestnik/:title
+        permalink: /:collection/:title
 sass:
     sass_dir: assets/_scss
     style: compressed

--- a/_config.yml
+++ b/_config.yml
@@ -36,6 +36,9 @@ collections:
     datasety:
         output: true
         permalink: /datasety/:title
+    rozcestniky:
+        output: true
+        permalink: /rozcestnik/:title
 sass:
     sass_dir: assets/_scss
     style: compressed

--- a/_includes/preview-blocks.html
+++ b/_includes/preview-blocks.html
@@ -34,6 +34,14 @@
                 <div class="card-img-overlay tags-overlay-box">
                     {% include tags.html tags=item.tags %}
                 </div>
+            {% when 'signpost' %}
+                <div class="card-body">
+                    <h5>{{ item.title }}</h5>
+                    <p class="card-text mt-3">{{ item.caption }}</p>
+                </div>
+                <div class="card-img-overlay tags-overlay-box">
+                    {% include tags.html tags=item.tags %}
+                </div>
             {% else %}
                 <p>Unknown layout.</p>
             {% endcase %}

--- a/_layouts/signpost.html
+++ b/_layouts/signpost.html
@@ -1,0 +1,34 @@
+<!doctype html>
+<html lang="cs">
+<head>
+  {% include header.html %}
+</head>
+
+<body>
+  {% include navigation.html %}
+  <main role="main">
+    <div class="section">
+      <div class="container">
+        <h1>{{ page.title }}</h1>
+        {% include tags.html tags=page.tags link="true" %}
+        <p class="lead">{{ page.intro }}</p>
+
+        {{ content }}
+      </div>
+    </div>
+    {% assign related = site.infografiky | concat: site.studie | where_exp: "item", "item.tags contains page.tags-topics[0]"
+    | where_exp:"item","item.slug != page.slug" | sample: 3 %}
+    {% if related.size > 0 %}
+    <div class="section">
+      <div class="container">
+        <h2>Související infografiky a studie</h2>
+        <p>Zaujal vás tento rozcestník? Prozkoumejte další související infografiky a studie:</p>
+        {% include preview-blocks.html blocks=related limit=3 %}
+      </div>
+    </div>
+    {% endif %}
+  </main>
+  {% include footer.html %}
+  {% include scripts.html %}
+</body>
+</html>

--- a/_layouts/tag.html
+++ b/_layouts/tag.html
@@ -32,13 +32,15 @@
         {% endif %}
         {% for col in page.collections %}
           <h2>{{col[0]}} <small class="text-secondary">({{ col[1]|size }})</small></h2>
-          {% case forloop.index %}
-            {% when 1 %}
+          {% case col[0] %}
+            {% when 'infografiky' %}
             <p class="lead">Naše infografiky týkající se tématu. Na stránce grafiky vždy naleznete zdroj dat i podrobnější informace.</p>
-            {% when 2 %}
+            {% when 'studie' %}
             <p class="lead">Naše shrnutí studií a analýz týkajících se tématu. Vždy uvádíme, proč je studie důležitá a jaké jsou její hlavní závěry.</p>
-            {% when 3 %}
+            {% when 'datasety' %}
             <p class="lead">Naše datasety vztahující se k tématu. Typicky kombinujeme více zdrojů a vysvětlujeme, jak přesně z nich vycházejí naše infografiky.</p>
+            {% when 'rozcestniky' %}
+            <p class="lead">Rozcestníky přehledně shrnují zdroje, které v souvislosti s daným tématem považujeme za důležité. U každé položky uvádíme základní charakteristiky a odkazy na původní materiály.</p>
           {% endcase %}
           {% assign items = col[1] | sort: "weight" %}
           {% include preview-blocks.html blocks=items %}

--- a/_rozcestniky/energentika/transformace-energetiky.html
+++ b/_rozcestniky/energentika/transformace-energetiky.html
@@ -1,10 +1,11 @@
 ---
 layout:      signpost
-title:       Studie transformace energetiky
+title:       Studie transformace energetiky (neveřejné)
 slug:        transformace-energetiky
 weight:      300
-tags-scopes: [ cr ]
-tags-topics: [ energetika, opatreni, budoucnost ]
+# tags-scopes: [ cr ]
+# tags-topics: [ energetika, opatreni, budoucnost ]
+sitemap:     false
 caption:     "Rozcestník shrnuje klíčové studie věnující se budoucí transformaci české energetiky z posledních let."
 intro: |
   Studií věnujících se transformaci energetiky je mnoho a přístupů, jak takové studie

--- a/_rozcestniky/energentika/transformace-energetiky.html
+++ b/_rozcestniky/energentika/transformace-energetiky.html
@@ -1,0 +1,221 @@
+---
+layout:      signpost
+title:       Studie transformace energetiky
+slug:        transformace-energetiky
+weight:      300
+tags-scopes: [ cr ]
+tags-topics: [ energetika, opatreni, budoucnost ]
+caption:     "Rozcestník shrnuje klíčové studie věnující se budoucí transformaci české energetiky z posledních let."
+intro: |
+  Studií věnujících se transformaci energetiky je mnoho a přístupů, jak takové studie
+  zpracovávat, je taktéž nemalé množství. Tento rozcestník podává přehledné shrnutí
+  klíčových studií v oblasti energetiky pro Českou republiku. Studie jsou seřazeny
+  chronologicky od nejstarší po nejnovější.
+items:
+  - title:   "Klimaticky neutrální Česko: Cesty k dekarbonizaci ekonomiky"
+    url:     "https://www.mckinsey.com/cz/~/media/mckinsey/locations/europe%20and%20middle%20east/czech%20republic/our%20work/decarbonization_report_cz_vf.pdf"
+    date:    Listopad 2020
+    authors:
+      - name: "McKinsey & Company"
+        url:  "https://www.mckinsey.com/"
+    timeframe: "2030, 2050"
+  - title:   "Coal-Free Czechia 2030"
+    date:    Listopad 2020
+    authors:
+      - name: Ember
+        url:  "https://ember-climate.org/"
+    timeframe: 2030
+    infographic: elektrina-cr
+  - title:   "Energy Transition Outlook 2020"
+    url:     "https://eto.dnvgl.com/2020/index.html"
+    date:    Září 2020
+    authors:
+      - name: DNV GL
+        url:  "https://www.dnvgl.com/"
+    timeframe: 2050
+  - title:   "Investing in the Recovery and Transition of Europe’s Coal Regions"
+    date:    Červenec 2020
+    url:     "https://about.bnef.com/blog/new-report-reveals-economic-path-to-a-rapid-coal-phase-out-in-europe/"
+    authors:
+      - name: BloombergNEF
+        url:  "https://about.bnef.com/"
+      - name: Bloomberg Philanthropies
+        url:  "https://www.bloomberg.org/"
+    timeframe: 2030
+    infographic: elektrina-cr
+  - title:   "Modernizace evropského hnědouhelného trojúhelníku: Směrem k bezpečné, dostupné a udržitelné transformaci energetiky"
+    url:     "https://www.agora-energiewende.de/fileadmin2/Partnerpublikationen/2020/Lignite_Triangle/CZ-Modernizace_evropske__ho_hne__douhelne__ho_troju__helni__ku_net.pdf"
+    date:    Červen 2020
+    authors:
+      - name: Aurora Energy Research
+        url:  "https://www.auroraer.com/"
+      - name: Forum Energii
+        url:  "https://www.forum-energii.eu/"
+      - name: Agora Energiewende
+        url:  "https://www.agora-energiewende.de/en/"
+  - title:   "Scénáře budoucnosti české energetiky"
+    date:    Červen 2020 (interní)
+    authors:
+      - name: ČEPS
+        url:  "https://www.ceps.cz/cs/"
+    timeframe: 2030–2050
+  - title:   "Impacts of Green New Deal Energy Plans on Grid Stability, Costs, Jobs, Health, and Climate in 143 Countries"
+    date:    Prosinec 2019
+    url:     "https://www.cell.com/one-earth/fulltext/S2590-3322(19)30225-8"
+    authors:
+      - name: Stanford University
+        url:  https://cee.stanford.edu/
+    timeframe: 2050
+  - title:   "Rozvoj obnovitelných zdrojů do roku 2030"
+    date:    Září 2019
+    url:     "https://www2.deloitte.com/content/dam/Deloitte/cz/Documents/energy-resources/rozvoj_obnovitelnych_zdroju_do_roku_2030_3.pdf"
+    authors:
+      - name: Deloitte
+        url:  "https://www2.deloitte.com/cz/cs.html"
+    timeframe: 2030
+  - title:   "Vnitrostátní plán v oblasti energetiky a klimatu České republiky (NECP)"
+    url:     "https://www.mpo.cz/cz/energetika/strategicke-a-koncepcni-dokumenty/navrh-vnitrostatniho-planu-v-oblasti-energetiky-a-klimatu-ceske-republiky--243377/"
+    date:    Únor 2019
+    authors:
+      - name: Ministerstvo průmyslu a obchodu ČR
+        url:  https://mpo.cz/
+    timeframe: 2030–2040
+    infographic: elektrina-cr
+  - title:   "Czech Power Grid without Electricity from Coal by 2030"
+    url:     "https://en.frankbold.org/sites/default/files/publikace/czech_grid_without_coal_by_2030_fin_0.pdf"
+    date:    Květen 2018
+    authors:
+      - name: Energynautics
+        url:  https://energynautics.com/en/
+    timeframe: 2050
+    infographic: elektrina-cr
+    study:       2018_energetika-cr-bez-uhli
+  - title:   "Global Energy System based on 100% Renewable Energy – Power Sector"
+    url:     "http://energywatchgroup.org/wp-content/uploads/2017/11/Full-Study-100-Renewable-Energy-Worldwide-Power-Sector.pdf"
+    date:    Listopad 2017
+    authors:
+      - name: Lappeenranta University of Technology
+        url:  https://www.lut.fi/web/en/
+      - name: Energy Watch Group
+        url:  https://energywatchgroup.org/
+    timeframe: 2030–2050
+  - title:   "80% snížení emisí skleníkových plynů: analýza vývoje energetiky České republiky do roku 2050"
+    url:     "https://idea.cerge-ei.cz/files/IDEA_Studie_21_2016_Snizeni_emisi_sklenikovych_plynu.pdf"
+    date:    Prosinec 2016
+    authors:
+      - name: Institut pro demokracii a ekonomickou analýzu
+        url:  https://idea.cerge-ei.cz/
+    timeframe: 2030–2050
+  - title:   "Aktualizovaná státní energetická koncepce"
+    url:     "https://www.mpo.cz/dokument158059.html"
+    date:    Srpen 2015
+    authors:
+      - name: Ministerstvo průmyslu a obchodu ČR
+        url:  https://mpo.cz/
+    timeframe: 2030–2045
+  - title:   "Energetická [r]evoluce"
+    url:     "https://storage.googleapis.com/planet4-czech-republic-stateless/2018/10/c6cea469-c6cea469-er-pro-%C4%8Cr-2012.pdf"
+    date:    Červen 2012
+    authors:
+      - name: Německé středisko pro letectví a kosmonautiku
+        url:  https://www.dlr.de/
+    timeframe: 2030–2050
+---
+{% comment %}
+  Verze rozcestníku pro menší displeje: seznam kartiček pod sebou.
+{% endcomment %}
+<div class="d-md-none mt-4">
+  {% for item in page.items %}
+  <div class="card mb-3">
+    <div class="card-body">
+      {% if item.url %}
+      <h3 class="card-title"><a href="{{ item.url }}">{{ item.title }}</a></h3>
+      {% else %}
+      <h3 class="card-title">{{ item.title }}</h3>
+      {% endif %}
+      <p class="card-text text-muted">{{ item.date }}</p>
+      <dl>
+        <dt>Zpracovatel</dt>
+        <dd>
+        {% for author in item.authors -%}
+        {%- if forloop.index > 1 %},{% endif %}
+        {% if author.url %}
+        <a href="{{ author.url }}">{{ author.name }}</a>
+        {%- else -%}
+        {{ author.name }}
+        {%- endif -%}
+        {% endfor %}
+        </dd>
+
+        {% if item.timeframe %}
+        <dt>Časový horizont</dt>
+        <dd>{{ item.timeframe }}</dd>
+        {% endif %}
+      </dl>
+
+      <div class="d-flex flex-column flex-sm-row justify-content-end">
+        <div class="d-flex flex-column flex-sm-row">
+          {% comment %}
+          {% if item.infographic %}
+          <a href="/infografiky/{{ item.infographic }}" class="btn btn-sm btn-primary my-sm-0">Infografika</a>
+          {% endif %}
+          {% endcomment %}
+          {% if item.study %}
+          <a href="/studie/{{ item.study }}" class="btn btn-sm btn-primary my-sm-0">Shrnutí studie</a>
+          {% endif %}
+        </div>
+      </div>
+    </div>
+  </div>
+  {% endfor %}
+</div>
+
+{% comment %}
+  Plná verze rozcestníku: tabulka s jednotlivými studiemi.
+{% endcomment %}
+<table class="table table-striped d-none d-md-table mt-5">
+  <thead>
+    <tr>
+      <th scope="col">Název studie</th>
+      <th scope="col">Datum zveřejnění</th>
+      <th scope="col">Zpracovatel</th>
+      <th scope="col">Časový horizont</th>
+      <th scope="col">Naše materiály</th>
+    </tr>
+  </thead>
+  <tbody>
+    {% for item in page.items %}
+    <tr>
+      <td>
+        {% if item.url %}
+        <a href="{{ item.url }}">{{ item.title }}</a>
+        {% else %}
+        {{ item.title }}
+        {% endif %}
+      </td>
+      <td>{{ item.date }}</td>
+      <td>
+        {% for author in item.authors -%}
+        {%- if forloop.index > 1 %},{% endif %}
+        {% if author.url %}
+        <a href="{{ author.url }}">{{ author.name }}</a>
+        {%- else -%}
+        {{ author.name }}
+        {%- endif -%}
+        {% endfor %}
+      </td>
+        <td>{% if item.timeframe %}{{ item.timeframe }}{% else %}—{% endif %}</td>
+      <td>
+        {% comment %}
+        {% if item.infographic %}
+        <a href="/infografiky/{{ item.infographic }}" class="btn btn-sm btn-secondary mt-0">Infografika</a>
+        {% endif %}
+        {% endcomment %}
+        {% if item.study %}
+        <a href="/studie/{{ item.study }}" class="btn btn-sm btn-secondary my-0">Shrnutí</a>
+        {% endif %}
+      </td>
+    </tr>
+    {% endfor %}
+  </tbody>
+</table>


### PR DESCRIPTION
Návrh realizace nového typu obsahu – rozcestníku materiálů, studií, odkazů atd.

Prvním příkladem je rozcestník studí k transformaci české energetiky zpracovaný dle Oldovy tabulky.

K některým studiím budeme mít i doprovodné infografiky. Ty všask ještě čekají na zveřejnění, tudíž je kód pro odkazy na infografiky prozatím zakomentovaný. Odkaz na jedno shrnutí studie (Energynautics) je funkční.

Known issues:

* Na stránce štítku se zobrazuje nadpis "rozcestniky" (s krátkým i).
* Omezená rozšiřitelnost, zobecnitelnost.

Náhled:
![Screenshot_2020-11-13 Studie transformace energetiky](https://user-images.githubusercontent.com/134321/99063186-65efa300-25a4-11eb-9df7-9a2c277abdff.png)
