### PR TITLE
Odstranění rozbalovací sekce na začátku textu

### DIFF
--- a/_includes/_texts/energeticke-scenare/jak-cist.md
+++ b/_includes/_texts/energeticke-scenare/jak-cist.md
@@ -1,9 +1,6 @@
 V této infografice dáváme základní přehled o jednom scénáři transformace české elektroenergetiky do roku 2030. Tato grafika je součastí kolekce grafik k různým scénářům vývoje elektroenergetiky v ČR včetně [srovnání všech těchto scénářů](/infografiky/srovnani-energetickych-scenaru-cr) na jedné grafice.
 
-<details markdown=1>
-<summary>
-<h2>Jak číst tento graf</h2>
-</summary>
+## Jak číst tento graf
 
 Stav v roce 2019 a stav v roce 2030 podle tohoto scénáře srovnáváme ve dvou hlavních parametrech:
 1. **Instalovaný výkon (dole):** Tento parametr zachycuje, jaké elektrárny máme a můžeme v budoucnu mít. Tedy kolik bude v Česku konvenčních elektráren na uhlí nebo na plyn, kolik solárních panelů a kolik větrných elektráren, kolik bioplynových stanic, kolik tepláren na biomasu, apod. Čtverečky zobrazují instalovaný výkon, ale nijak nevypovídají o zastavěné ploše, která by byla pro každý typ elektráren jiná.
@@ -14,5 +11,3 @@ Stav v roce 2019 a stav v roce 2030 podle tohoto scénáře srovnáváme ve dvou
 **Emise skleníkových plynů:** Postupný odklon od fosilních zdrojů a nejvíce pak od uhlí znamená snížení emisí skleníkových plynů. Každá studie takové snížení počítá pomocí vlastní metodiky (a nebo nepočítá vůbec). Proto pro všechny studie **uvádíme náš výpočet snížení emisí** založený na rozdílu v mixu výroby mezi lety 2019 a 2030 a na emisních koeficientech od <glossary id=ipcc>IPCC</glossary>. Více o metodice výpočtu najdete níže.
 
 {% include _texts/energeticke-scenare/v-cem-se-shoduji.md %}
-
-</details>

--- a/_infografiky/energetika/srovnani-energetickych-scenaru-cr.md
+++ b/_infografiky/energetika/srovnani-energetickych-scenaru-cr.md
@@ -22,10 +22,7 @@ V této infografice dáváme srovnání více scénářů vývoje [elektroenerge
 <a href="/studie/2020-scenar-bloombergnef" class="btn btn-secondary">BloombergNEF</a>
 <a href="/studie/2019-scenar-necp" class="btn btn-secondary">NECP</a>.
 
-<details markdown=1>
-<summary>
-<h2>Jak číst tento graf</h2>
-</summary>
+## Jak číst tento graf
 
 **V horní části grafiky** srovnáváme stav v roce 2019 a stav v roce 2030 podle **výroby elektřiny**: Tento parametr zachycuje, kolik které zdroje elektřiny dodají do přenosové soustavy. Formálně je to tzv. _čistá výroba_, která nepočítá elektřinu, kterou elektrárny samy spotřebují. Snížení celkové výroby znamená, že se (vlivem úspor) sníží spotřeba, že se sníží _čistý vývoz_ nebo že dokonce budeme více elektřiny dovážet než vyvážet.
 
@@ -42,7 +39,6 @@ Scénáře se liší v **míře předvídaného [uhelného phase-outu](/infograf
 Scénáře se v poslední řadě liší ve svém **zaměření a metodice**. Například scénář Energynautics se zaměřuje na stabilitu přenosové soustavy a proto stanovuje instalovaný výkon jednotlivých zdrojů na základě expertních odhadů. Naopak scénáře Ember a BloombergNEF hledají změny v instalovaném výkonu pomocí tržní optimalizace. Scénář Ember při tom zkoumá, jak by vypadala varianta úplného uhelného phase-outu, zatímco scénář BloombergNEF posuzuje variantu s celkově nejnižšími náklady.
 
 {% include _texts/energeticke-scenare/v-cem-se-shoduji.md %}
-</details>
 
 <details markdown=1>
 <summary>


### PR DESCRIPTION
Na začátku doprovodného textu by měl být nějaký text, který se dá okamžitě číst, aniž by člověk musel na něco klikat. Rozbalovací
sekce mi na tomto místě nedávají smysl. Navrhuju je proto v úvodním bloku odstranit a nechat je jenom u doplňujících sekcí.