### PR TITLE
Možnost odkazovat na rozbalovací sekce

### DIFF
--- a/_infografiky/emise/potencial-zpusobu-snizeni-emisi.md
+++ b/_infografiky/emise/potencial-zpusobu-snizeni-emisi.md
@@ -22,8 +22,8 @@ V pravém sloupci ukazujeme potenciál úspor, které přímo nesouvisí s indiv
 V této sekci vysvětlujeme podrobněji jednotlivé odhady a předpoklady, ze kterých vycházíme. Přesné odvození jednotlivých čísel najdete v naší tabulce s daty.
 
 <details markdown=1>
-<summary>
-<h3>Osobními auty ujedeme polovinu vzdálenosti</h3>
+<summary markdown=1>
+### Osobními auty ujedeme polovinu vzdálenosti
 </summary>
 
 Největší skupina českých řidičů najede ročně mezi [5 až 10 tisíci km](https://www.opojisteni.cz/pojistny-trh/pojistne-produkty/pruzkum-pojistovny-direct-jak-cesi-jezdi/c:11746/) a osobní automobily zodpovídají v ČR celkem za 11,9 milionů tun emisí <glossary id="co2eq">CO<sub>2</sub>eq</glossary>. **Kdyby se celkový roční nájezd snížil na polovinu, ušetřilo by se ročně asi 5,9 milionů tun emisí CO<sub>2</sub>eq.**
@@ -32,8 +32,8 @@ Takového snížení by bylo možné dosáhnout např. ještě vyšším využí
 </details>
 
 <details markdown=1>
-<summary>
-<h3>Nalétáme polovinu vzdálenosti</h3>
+<summary markdown=1>
+### Nalétáme polovinu vzdálenosti
 </summary>
 
 Letecká doprava odpovídá za přibližně 2,5 % světových emisí CO<sub>2</sub> (bez EWF, viz níže), rozpočítávání emisí na jednotlivé státy je ale komplikované. Většina "emisních účetnictví" počítá emise podle dopravy z letišť na území daného státu (pro ČR zejména Praha-Ruzyně). V tomto přístupu budou emise lidí z ČR mírně podhodnocené, neboť Češi využívají také letiště ve Vídni či Bratislavě. EUROSTAT uvádí, že emise z letecké dopravy v ČR v roce 2018 byly 1,25 milionů tun <glossary id="co2eq">CO<sub>2</sub>eq</glossary>. Spalováním leteckého benzínu vzniká nejen oxid uhličitý, ale i oxidy dusíku (NO<sub>X</sub>) a síry. Vypouštění těchto emisí vysoko v atmosféře vytváří ozon (skleníkový plyn) a kondenzační stopy, které je nutné započítat do celkového radiačního působení vypouštěných emisí. To se prakticky provádí pomocí EWF (emission weighting factor). Pro náš výpočet vycházíme ze [studie](https://link.springer.com/article/10.1007/s10584-011-0168-8), která odhaduje střední hodnotu EWF na 1,7. **Kdyby obyvatelé ČR nalétali poloviční vzdálenost, snížily by se efektivní emise ČR o 1,1 milionů tun CO<sub>2</sub>eq.**
@@ -42,8 +42,8 @@ Pro dopravu na kratší vzdálenosti v rámci Evropy je možné letadla částe�
 </details>
 
 <details markdown=1>
-<summary>
-<h3>Zkonzumujeme poloviční množství mléka a mléčných výrobků / masa</h3>
+<summary markdown=1>
+### Zkonzumujeme poloviční množství mléka a mléčných výrobků / masa
 </summary>
 
 Podle Českého statistického úřadu sní průměrný Čech ročně asi 70 kg masa, z toho je přibližně 6 kg hovězího. Při započtení všech druhů masa, včetně rozlišení mléčného a masného skotu, jsou emise související se spotřebou masa v ČR celkem 6,8 milionů tun <glossary id="co2eq">CO<sub>2</sub>eq</glossary>. V této hodnotě je započten celý cyklus výroby, tedy obsahuje například i krmivo či doprava do obchodu. Zároveň je třeba poznamenat, že část produkce masa se do ČR dováží, takže hodnota odpovídá emisím souvisejícím se spotřebovaným masem, nikoliv s masem produkovaným v ČR. **Pokud by lidé spotřebovali poloviční množství masa, ušetřilo by se ročně 3,4 milionů tun emisí CO<sub>2</sub>eq.**
@@ -56,8 +56,8 @@ Emisní koeficienty celého cyklu produkce potravin přebíráme ze zdroje [Our 
 </details>
 
 <details markdown=1>
-<summary>
-<h3>Snížíme spotřebu elektřiny v domácnostech na polovinu</h3>
+<summary markdown=1>
+### Snížíme spotřebu elektřiny v domácnostech na polovinu
 </summary>
 
 V domácnostech se spotřebuje asi jen 17 % elektřiny, která je v ČR vyrobena a zároveň výroba elektřiny a tepla vyprodukuje téměř 40 % ročních emisí ČR. Je tedy vhodné pokládat si otázku k jak velkému snížení emisí by vedla úspora elektřiny v domácnostech. Abychom mohli takový odhad udělat, musíme učinit několik předpokladů o výrobě, spotřebě a trhu s elektřinou, které nejsou samozřejmé.
@@ -73,8 +73,8 @@ Je třeba mít na paměti, že pokud výroba elektřiny v Česku projde v dalš�
 </details>
 
 <details markdown=1>
-<summary>
-<h3>Omezíme emise z vytápění a ohřevu vody na polovinu</h3>
+<summary markdown=1>
+### Omezíme emise z vytápění a ohřevu vody na polovinu
 </summary>
 
 Podle EUROSTATu způsobilo spalování v domácnostech v roce 2018 emise oxidu uhličitého ve výši 9,1 Mt <glossary id="co2eq">CO<sub>2</sub>eq</glossary>. Spalování v domácnostech primárně znamená lokální vytápění a ohřev vody, malou část také tvoří vaření na zemním plynu. **Kdyby se tyto emise snížily na polovinu, pak ušetříme 4,6 Mt CO<sub>2</sub>eq.**
@@ -87,8 +87,8 @@ Nástroje ke snížení emisí existují: pokračující zateplení budov, moder
 Přesné odvození jednotlivých čísel opět najdete v naší tabulce s daty.
 
 <details markdown=1>
-<summary>
-<h3>Výsadba 10 milionů stromů navíc</h3>
+<summary markdown=1>
+### Výsadba 10 milionů stromů navíc
 </summary>
 
 Vysazování stromů bývá považováno za důležitý nástroj k sekvestraci uhlíku, což se promítá i do některých politických [prohlášení](https://www.facebook.com/AndrejBabis/posts/1636697499800221/). Deset milionů stromů volíme symbolicky (jeden strom na jednoho občana ČR) a také v návaznosti na stejný cíl projektu Sázíme budoucnost založený Nadací Partnerství a zaštítěný Ministerstvem životního prostředí. Cílem projektu je do roku 2025 vysázet 10 milionů nových stromů mimo území lesa (tedy tvorbou nových alejí, sadů, remízků, větrolamů, atd.)
@@ -107,8 +107,8 @@ Sekvestrace uhlíku samozřejmě není jediné kritérium. Sázení nových stro
 </details>
 
 <details markdown=1>
-<summary>
-<h3>Sekvestrace na orné půdě (změna hospodaření)</h3>
+<summary markdown=1>
+### Sekvestrace na orné půdě (změna hospodaření)
 </summary>
 
 Zemědělská půda přirozeně váže uhlík a v závislosti na zvolené technice hospodaření se množství vázaného uhlíku v průběhu let zvyšuje nebo klesá. V uplynulých dekádách na různých místech světa probíhají dlouhodobé studie, které srovnávají různé techniky hospodaření podle jejich sekvestračního potenciálu. Podle [studie](https://aa.ecn.cz/img_upload/410697af7dfcb092dfd4e3937dd69e3f/klima_co2_web_final.pdf) Organizace pro výživu a zemědělství (která spadá pod OSN) může hektar půdy obdělávané v režimu ekologického zemědělství uložit okolo 200 kg CO<sub>2</sub> za rok. Když se k tomu dále přidají techniky minimálního zpracování orné půdy, zvýší se sekvestrační potenciál na přibližně 500 kg CO<sub>2</sub> za rok. U vyčerpaných půd může být tato sekvestrace ještě vyšší, dlouhodobé studie ukazují, že sekvestrační potenciál se příliš nesnižuje ani po 30 letech takového hospodaření.
@@ -121,8 +121,8 @@ Přechod na takový režim zemědělství by v mnoha oblastech by vedl ke sníž
 </details>
 
 <details markdown=1>
-<summary>
-<h3>Snížení emisí ze skládek odpadu na polovinu</h3>
+<summary markdown=1>
+### Snížení emisí ze skládek odpadu na polovinu
 </summary>
 
 Jednou z oblastí, kde emise České republiky od roku 1990 rostou, je odpadové hospodářství. Na skládkách skončí ročně cca 2,7 milionů tun odpadu a při jeho rozkládání vzniká především metan, který je silným skleníkovým plynem. Ročně tak emise skleníkových plynů ze skládek odpovídají 3,7 miliónů tun <glossary id="co2eq">CO<sub>2</sub>eq</glossary>, což je o 80 % více než v roce 1990. Kdyby se podařilo snížit emise ze skládkování odpadu na polovinu, uspořilo by to 1,8 miliónů tun CO<sub>2</sub>eq ročně.
@@ -131,8 +131,8 @@ Možností, jak snížit množství odpadů na skládkách je mnoho: v duchu hes
 </details>
 
 <details markdown=1>
-<summary>
-<h3>Změna energetického mixu</h3>
+<summary markdown=1>
+### Změna energetického mixu
 </summary>
 
 Při pohledu na [emise skleníkových plynů](/infografiky/emise-cr-detail) v ČR dle podle sektorů je na první pohled patrné, že největší podíl emisí připadá na výrobu elektřiny. V roce 2018 to bylo 39,5 % celkových emisí ČR. Je to dáno tím, že většina elektřiny se v ČR stále získává spalováním hnědého uhlí. Uhelné elektrárny se tak v roce 2018 podílely na výrobě elektřiny ze 47 %, přitom ale vyprodukovaly na 88 % všech emisí v daném sektoru.

--- a/_infografiky/energetika/srovnani-energetickych-scenaru-cr.md
+++ b/_infografiky/energetika/srovnani-energetickych-scenaru-cr.md
@@ -41,8 +41,8 @@ Scénáře se v poslední řadě liší ve svém **zaměření a metodice**. Nap
 {% include _texts/energeticke-scenare/v-cem-se-shoduji.md %}
 
 <details markdown=1>
-<summary>
-<h2>Metodické komentáře ke grafice</h2>
+<summary markdown=1>
+## Metodické komentáře ke grafice
 </summary>
 
 ### Rozdělení zdrojů do kategorií: rok 2019

--- a/_infografiky/opatreni/adaptacni-strategie-cr.md
+++ b/_infografiky/opatreni/adaptacni-strategie-cr.md
@@ -57,8 +57,8 @@ Věda a výzkum mají zásadní roli při zdokonalování adaptace na změnu kli
 
 
 <details markdown=1>
-<summary>
-<h2>Lesní hospodářství</h2>
+<summary markdown=1>
+## Lesní hospodářství
 </summary>
 
 * **Dopady**  
@@ -73,8 +73,8 @@ Věda a výzkum mají zásadní roli při zdokonalování adaptace na změnu kli
 </details>
 
 <details markdown=1>
-<summary>
-<h2>Zemědělství</h2>
+<summary markdown=1>
+## Zemědělství
 </summary>
 
 * **Dopady**  
@@ -89,8 +89,8 @@ Věda a výzkum mají zásadní roli při zdokonalování adaptace na změnu kli
 </details>
 
 <details markdown=1>
-<summary>
-<h2>Vodní hospodářství</h2>
+<summary markdown=1>
+## Vodní hospodářství
 </summary>
 
 * **Dopady**  
@@ -105,8 +105,8 @@ Věda a výzkum mají zásadní roli při zdokonalování adaptace na změnu kli
 </details>
 
 <details markdown=1>
-<summary>
-<h2>Města (Urbanizovaná krajina)</h2>
+<summary markdown=1>
+## Města (urbanizovaná krajina)
 </summary>
 
 * **Dopady**  
@@ -121,8 +121,8 @@ Věda a výzkum mají zásadní roli při zdokonalování adaptace na změnu kli
 </details>
 
 <details markdown=1>
-<summary>
-<h2>Biodiverzita a ekosystémové služby</h2>
+<summary markdown=1>
+## Biodiverzita a ekosystémové služby
 </summary>
 
 * **Dopady**  
@@ -137,8 +137,8 @@ Věda a výzkum mají zásadní roli při zdokonalování adaptace na změnu kli
 </details>
 
 <details markdown=1>
-<summary>
-<h2>Zdraví a hygiena</h2>
+<summary markdown=1>
+## Zdraví a hygiena
 </summary>
 
 * **Dopady**  
@@ -153,8 +153,8 @@ Věda a výzkum mají zásadní roli při zdokonalování adaptace na změnu kli
 </details>
 
 <details markdown=1>
-<summary>
-<h2>Cestovní ruch</h2>
+<summary markdown=1>
+## Cestovní ruch
 </summary>
 
 * **Dopady**  
@@ -167,8 +167,8 @@ Věda a výzkum mají zásadní roli při zdokonalování adaptace na změnu kli
 </details>
 
 <details markdown=1>
-<summary>
-<h2>Doprava</h2>
+<summary markdown=1>
+## Doprava
 </summary>
 
 * **Dopady**  
@@ -182,8 +182,8 @@ Věda a výzkum mají zásadní roli při zdokonalování adaptace na změnu kli
 </details>
 
 <details markdown=1>
-<summary>
-<h2>Průmysl a energetika</h2>
+<summary markdown=1>
+## Průmysl a energetika
 </summary>
 
 * **Dopady**  
@@ -198,8 +198,8 @@ Věda a výzkum mají zásadní roli při zdokonalování adaptace na změnu kli
 </details>
 
 <details markdown=1>
-<summary>
-<h2>Mimořádné události a ochrana obyvatelstva</h2>
+<summary markdown=1>
+## Mimořádné události a ochrana obyvatelstva
 </summary>
 
 * **Dopady**  

--- a/_infografiky/teploty/cykly-koncentrace-co2.md
+++ b/_infografiky/teploty/cykly-koncentrace-co2.md
@@ -23,8 +23,8 @@ dataset:    "koncentrace-co2"
 
 
 <details markdown=1>
-<summary>
-<h2>Jak se měří koncentrace CO<sub>2</sub> a O<sub>2</sub>?</h2>
+<summary markdown=1>
+## Jak se měří koncentrace CO<sub>2</sub> a O<sub>2</sub>?
 </summary>
 
 * Přesnou metodu měření, která dokáže koncentraci stanovit s přesností 0,1 ppm, tedy 0,00001 %, vyvinul Charles Keeling v roce 1952. Nejprve byl výsledky svých měření překvapen, protože zaznamenával různé koncentrace ve dne a v noci a také se měnily podle toho, odkud foukal vítr. Došlo mu, že jeho měření v San Francisku ovlivňují okolní lesy (fotosyntéza) a továrny (spalování) a že potřebuje měřit na místě, které bude od takových vlivů velmi vzdálené. Přesunul se tedy doprostřed Tichého oceánu na Mauna Loa na Havaji, stanici, která leží 3400 metrů nad mořem. Nejdelší konzistentní řada měření koncentrací CO<sub>2</sub> je právě z Mauna Loa. Od té doby se přidaly další měřicí stanice v Antarktidě, Aljašce a některých dalších ostrovech v Tichém oceánu. Všechna tato místa vykazují stejný dlouhodobý pokles a podobné kolísání mezi létem a zimou. (Velikost kolísání je v různých místech různá. Obecně na severní polokouli je větší a na jižní polokouli menší – záleží na vzdálenosti od velkých lesů, které svým dýcháním tyto koncentrace ovlivňují.)
@@ -35,8 +35,8 @@ dataset:    "koncentrace-co2"
 
 
 <details markdown=1>
-<summary>
-<h2>Jak se projevuje fotosyntéza, dýchání a spalování fosilních paliv na koncentracích CO<sub>2</sub> a O<sub>2</sub>?</h2>
+<summary markdown=1>
+## Jak se projevuje fotosyntéza, dýchání a spalování fosilních paliv na koncentracích CO<sub>2</sub> a O<sub>2</sub>?
 </summary>
 
 * Při fotosyntéze rostliny spotřebovávají oxid uhličitý z atmosféry a vydechují kyslík. Dýchání je opačný proces, při kterém se kyslík spotřebovává a oxid uhličitý vydechuje: CO<sub>2</sub> + H<sub>2</sub>O ↔ O<sub>2</sub> + sacharidy. Většina světových lesů se nachází na severní polokouli. V létě mají listnaté stromy listy a převažuje fotosyntéza  – rostliny odčerpávají oxid uhličitý z atmosféry a ukládají uhlík do svých kmenů a listů. Na podzim stromy shazují listy, které hnijí a uvolňují oxid uhličitý zpět do atmosféry. Dýchání kyslík mimo vegetační sezónu spotřebovává. Tak vzniká pravidelné kolísání koncentrací kyslíku a CO<sub>2</sub>.
@@ -47,8 +47,8 @@ dataset:    "koncentrace-co2"
 
 
 <details markdown=1>
-<summary>
-<h2>Jak víme, že nárůst koncentrací CO<sub>2</sub> je důsledkem spalování fosilních paliv?</h2>
+<summary markdown=1>
+## Jak víme, že nárůst koncentrací CO<sub>2</sub> je důsledkem spalování fosilních paliv?
 </summary>
 
 Důkazů, že nárůst koncentrací CO<sub>2</sub> je způsoben spalováním fosilních paliv je několik:

--- a/_infografiky/teploty/historie-sklenikoveho-efektu.md
+++ b/_infografiky/teploty/historie-sklenikoveho-efektu.md
@@ -20,8 +20,8 @@ Tato časová osa vychází z těchto dvou přehledových publikací o výzkumu 
 
 
 <details markdown=1>
-<summary>
-<h2>Více o jednotlivých událostech a objevech</h2>
+<summary markdown=1>
+## Více o jednotlivých událostech a objevech
 </summary>
 
 * **1824:** *[J.B Fouriere](https://en.wikipedia.org/wiki/Joseph_Fourier#Discovery_of_the_greenhouse_effect)* ze známé vzdálenosti Země od Slunce a měření intenzity slunečního záření vypočítal, jaká by měla být průměrná teplota Země, kdyby byla pouze ohřívána Sluncem. Protože mu vycházela teplota nižší, než jaká je skutečně měřená, uvažoval o dalších možných zdrojích tepla (např. o kosmickém záření), nebo o možném izolačním efektu atmosféry. Jakým mechanismem atmosféra může zachycovat teplo objevil o 35 let později John Tyndall.
@@ -50,8 +50,8 @@ Tato časová osa vychází z těchto dvou přehledových publikací o výzkumu 
 </details>
 
 <details markdown=1>
-<summary>
-<h2>Další odkazy a poznámky</h2>
+<summary markdown=1>
+## Další odkazy a poznámky
 </summary>
 
 * [Analýza citovanosti](https://www.carbonbrief.org/the-most-influential-climate-change-papers-of-all-time) z časopisu Carbon Brief, ukazuje, že nevlivnější, tedy nejvíce citované články o klimatu jsou následující:

--- a/_infografiky/teploty/koncentrace-co2.md
+++ b/_infografiky/teploty/koncentrace-co2.md
@@ -22,8 +22,8 @@ dataset:    "koncentrace-co2"
 
 
 <details markdown=1>
-<summary>
-<h2>Jak se měří historické koncentrace CO<sub>2</sub>?</h2>
+<summary markdown=1>
+## Jak se měří historické koncentrace CO<sub>2</sub>?
 </summary>
 
 * Vzorky ledu z hloubkových ledovcových vrtů (až 3 800 m) obsahují velmi starý led (až 800 000 let). Fyzikální vlastnosti tohoto ledu vypovídají o podmínkách v dobách, kdy led zamrzl. Z množství isotopů kyslíku a vodíku lze určit tehdejší průměrnou teplotu planety, z bublinek zachycených v ledu lze určit složení tehdejšího vzduchu.
@@ -36,8 +36,8 @@ dataset:    "koncentrace-co2"
 
 
 <details markdown=1>
-<summary>
-<h2>Jak víme, že nárůst koncentrací CO<sub>2</sub> je důsledkem spalování fosilních paliv?</h2>
+<summary markdown=1>
+## Jak víme, že nárůst koncentrací CO<sub>2</sub> je důsledkem spalování fosilních paliv?
 </summary>
 
 Důkazů, že nárůst koncentrací CO<sub>2</sub> je způsoben spalováním fosilních paliv je několik:

--- a/_infografiky/teploty/teplota-22000-let.md
+++ b/_infografiky/teploty/teplota-22000-let.md
@@ -30,8 +30,8 @@ data-orig:	[ [ "Zdrojová data NASA GISS", "https://data.giss.nasa.gov/gistemp/m
 
 
 <details markdown=1>
-<summary>
-<h2>Jak se zjišťuje teplota v minulosti?</h2>
+<summary markdown=1>
+## Jak se zjišťuje teplota v minulosti?
 </summary>
 
 * Teploty naměřené teploměry máme k dispozici pouze posledních zhruba 150 let. Abychom zjistili, jaké teploty panovaly na různých místech dříve v historii, je nutné teplotu zrekonstruovat za pomoci tzv. proxy měření. Nejčastěji používaným proxy měřením je měření relativních koncentrací izotopů kyslíku v hloubkových vrtech. Jak se v historii postupně usazovaly ledovce a mořské sedimenty, byly v nich zachycovány malé bublinky vzduchu. Poměr izotopů kyslíku v těchto zachycených bublinkách závisí na teplotě, která v době usazení v okolí panovala. Vědci tedy provádějí hloubkové vrty do ledovců a mořských sedimentů, kde věk vzorku se zvyšuje s hloubkou vrtu, a dokáží tak časově zrekonstruovat historické průměrné teploty v místě vrtu.
@@ -42,8 +42,8 @@ data-orig:	[ [ "Zdrojová data NASA GISS", "https://data.giss.nasa.gov/gistemp/m
 
 
 <details markdown=1>
-<summary>
-<h2>Jak se předpovídá budoucí teplota?</h2>
+<summary markdown=1>
+## Jak se předpovídá budoucí teplota?
 </summary>
 
 * Díky znalosti radiačního efektu skleníkových plynů je možné předpovědět, o kolik se zvýší energie přicházející k Zemi při zvýšení koncentrace skleníkových plynů. Protože v zemském klimatu působí různé pozitivní a negativní zpětné vazby, které výslednou teplotu ovlivňují, změna globální teploty se simuluje za pomoci klimatických modelů. Tyto modely jsou trénovány a testovány za pomoci historických dat.
@@ -54,8 +54,8 @@ data-orig:	[ [ "Zdrojová data NASA GISS", "https://data.giss.nasa.gov/gistemp/m
 
 
 <details markdown=1>
-<summary>
-<h2>Zdroje dat</h2>
+<summary markdown=1>
+## Zdroje dat
 </summary>
 
 * Shakun, J., Clark, P., He, F. et al. _Global warming preceded by increasing carbon dioxide concentrations during the last deglaciation._ Nature 484, 49–54 (2012). [DOI 10.1038/nature10915](https://doi.org/10.1038/nature10915)

--- a/_stranky/atlas.md
+++ b/_stranky/atlas.md
@@ -38,7 +38,9 @@ Klimatická změna je důležitým problémem současnosti, a je proto pevně sp
 Grafiky a texty projektu Fakta o klimatu chceme do budoucna provázet metodickými materiály, které učitelům, lektorům a dalším poslouží jako zdroj otázek a aktivit pro práci se žáky či studenty.
 
 <details markdown="1">
-<summary>Jak učit o klimatu a klimatické změně?</summary>
+<summary markdown=1>
+## Jak učit o klimatu a klimatické změně?
+</summary>
 
 Je mnoho způsobů jak uspořádat sérii vyučovacích hodin nebo přednášek o klimatické změně. Lze začít u zvyšování teplot, u emisí skleníkových plynů anebo třeba u dopadů změny na obyvatele různých oblastí. My jsme v Atlase uspořádali grafiky a texty tak, že ilustrují následující linku argumentů.
 
@@ -52,7 +54,9 @@ Je mnoho způsobů jak uspořádat sérii vyučovacích hodin nebo přednášek 
 </details>
 
 <details markdown="1">
-<summary>Recenzenti a poděkování</summary>
+<summary markdown=1>
+## Recenzenti a poděkování
+</summary>
 
 Atlas recenzovali:
 
@@ -68,7 +72,9 @@ Za odbornou či lidskou inspiraci chceme dále poděkovat: Jirkovi Vorlíčkovi,
 </details>
 
 <details markdown="1">
-<summary>Další díly a aktualizace atlasu</summary>
+<summary markdown=1>
+## Další díly a aktualizace atlasu
+</summary>
 
 V budoucnosti bychom rádi připravili další díly atlasu pokrývající například enegetiku a sénáře jejích transformací, emise, a další témata. Zároveň budeme první díl atlasu aktualizovat o nově vydávaná data.
 </details>

--- a/_studie/2018-scenar-energynautics.md
+++ b/_studie/2018-scenar-energynautics.md
@@ -20,8 +20,8 @@ data-orig:
 {% include _texts/energeticke-scenare/jak-cist.md %}
 
 <details markdown=1>
-<summary>
-<h2>Metodické komentáře ke grafice</h2>
+<summary markdown=1>
+## Metodické komentáře ke grafice
 </summary>
 {% include _texts/energeticke-scenare/rozdeleni-zdroju-2019.md %}
 
@@ -33,8 +33,8 @@ data-orig:
 </details>
 
 <details markdown=1>
-<summary>
-<h2>O studii Energynautics</h2>
+<summary markdown=1>
+## O studii Energynautics
 </summary>
 
 [Energynautics](https://energynautics.com/en/) je německá konzultační společnost, která se specializuje na analýzu elektrických sítí, jejich stabilitu a na integraci obnovitelných zdrojů do energetického mixu. Společnost disponuje vlastním softwarem, který umožňuje modelování a simulace provozu elektrizačních soustav.
@@ -67,8 +67,8 @@ Výroba a spotřeba elektřiny jsou modelovány v hodinovém rozlišení podle d
 </details>
 
 <details markdown=1>
-<summary>
-<h2>Výsledky studie Energynautics</h2>
+<summary markdown=1>
+## Výsledky studie Energynautics
 </summary>
 
 Hlavním závěrem studie je, že předpokládaný rozvoj obnovitelných zdrojů neohrozí stabilitu sítě ani bezpečnost dodávek elektřiny a stávající podoba přenosové sítě není pro takový rozvoj obnovitelných zdrojů energie překážkou. Navíc v hlavní variantě scénáře ČR zůstane čistým vývozcem elektřiny.

--- a/_studie/2019-scenar-necp.md
+++ b/_studie/2019-scenar-necp.md
@@ -15,8 +15,8 @@ data-orig:   	[ [ "Původní studie", "https://www.mpo.cz/cz/energetika/strategi
 {% include _texts/energeticke-scenare/jak-cist.md %}
 
 <details markdown=1>
-<summary>
-<h2>Metodické komentáře ke grafice</h2>
+<summary markdown=1>
+## Metodické komentáře ke grafice
 </summary>
 {% include _texts/energeticke-scenare/rozdeleni-zdroju-2019.md %}
 
@@ -28,8 +28,8 @@ data-orig:   	[ [ "Původní studie", "https://www.mpo.cz/cz/energetika/strategi
 </details>
 
 <details markdown=1>
-<summary>
-<h2>O scénáři NECP</h2>
+<summary markdown=1>
+## O scénáři NECP
 </summary>
 
 Národní energeticko-klimatický plán (NECP, National Energy and Climate Plan) dala

--- a/_studie/2020-scenar-bloombergnef.md
+++ b/_studie/2020-scenar-bloombergnef.md
@@ -15,8 +15,8 @@ data-orig:   [ [ "Původní studie", "https://data.bloomberglp.com/professional/
 {% include _texts/energeticke-scenare/jak-cist.md %}
 
 <details markdown=1>
-<summary>
-<h2>Metodické komentáře ke grafice</h2>
+<summary markdown=1>
+## Metodické komentáře ke grafice
 </summary>
 {% include _texts/energeticke-scenare/rozdeleni-zdroju-2019.md %}
 
@@ -28,8 +28,8 @@ Oproti číslům udávaným v samotné studii jen upravujeme výrobu vodních el
 </details>
 
 <details markdown=1>
-<summary>
-<h2>O studii BloombergNEF</h2>
+<summary markdown=1>
+## O studii BloombergNEF
 </summary>
 
 Scénář od agentury [BloombergNEF](https://about.bnef.com/) vznikl v rámci studie [Investing in the Recovery and Transition of Europe’s Coal Regions](https://about.bnef.com/blog/new-report-reveals-economic-path-to-a-rapid-coal-phase-out-in-europe/) (Investice do obnovy a transformace evropských uhelných regionů), která byla zveřejněna v červenci roku 2020.

--- a/_studie/2020-scenar-ember.md
+++ b/_studie/2020-scenar-ember.md
@@ -17,8 +17,8 @@ data-orig:
 {% include _texts/energeticke-scenare/jak-cist.md %}
 
 <details markdown=1>
-<summary>
-<h2>Metodické komentáře ke grafice</h2>
+<summary markdown=1>
+## Metodické komentáře ke grafice
 </summary>
 {% include _texts/energeticke-scenare/rozdeleni-zdroju-2019.md %}
 
@@ -36,8 +36,8 @@ Pro studii Ember je ještě třeba zdůraznit, že **ukazujeme úsporu emisí po
 </details>
 
 <details markdown=1>
-<summary>
-<h2>O studii Ember</h2>
+<summary markdown=1>
+## O studii Ember
 </summary>
 
 [Ember](https://www.ember-climate.org/) je nezávislý klimatický think tank, zaměřující se na urychlení světové transformace energetiky. Součástí jeho práce je zveřejňování dat o energetice či modelování možností transformace energetiky v různých částech světa.  Studie, ze které vycházíme v této vizualizaci, byla zveřejněna v listopadu 2020 a [shrnutí studie](https://ember-climate.org/wp-content/uploads/2020/11/Cesko_bez_uhli_od_2030_Ember.pdf) je k dispozici v češtině. Pokud vás zajímají bližší detaily ohledně metodiky modelování, předpokladů a dalších parametrů modelu, nahlédněte do [podrobné zprávy v angličtině](http://www.ember-climate.org/research/coal-free-cz-2030).
@@ -65,8 +65,8 @@ Tento zjednodušený přístup je použit i pro distribuci tepla. Tedy celá ČR
 </details>
 
 <details markdown=1>
-<summary>
-<h2>Metodika modelování studie Ember</h2>
+<summary markdown=1>
+## Metodika modelování studie Ember
 </summary>
 
 Ember pro tento model použil zavedený nástroj [Artelys Crystal Supergrid](https://www.artelys.com/crystal/super-grid/), který umožňuje plánovat a optimalizovat investice v elektrizační soustavě. Tento model stojí na řadě předpokladů:
@@ -104,8 +104,8 @@ Z toho vychází, že **v roce 2030 bude potřeba pokrýt 40 PJ tepla jako náhr
 </details>
 
 <details markdown=1>
-<summary>
-<h2>Výsledky studie Ember</h2>
+<summary markdown=1>
+## Výsledky studie Ember
 </summary>
 
 ### Náhrada uhlí ve výrobě elektřiny
@@ -137,8 +137,8 @@ Pro transformaci teplárenství odhadují náklady okolo 2,2 mld. euro. Toto zah
 </details>
 
 <details markdown=1>
-<summary>
-<h2>Varianty scénáře Ember</h2>
+<summary markdown=1>
+## Varianty scénáře Ember
 </summary>
 
 Ember ještě kromě hlavního scénáře modeloval dva alternativní.


### PR DESCRIPTION
Abychom mohli odkazovat na nadpis rozbalovací sekce, musí mít element svoje ID. Kramdown automaticky negeneruje ID pro raw HTML nadpisy, tudíž buď musíme vymyslet ID vlastní, nebo nadpis napsat v Markdown a nechat jej přechroustat Kramdownem. V tomto commitu jsem zvolil druhou cestu kvůli údržbovosti, i když první cesta je možná lepší z hlediska permalink-ovatelnosti.

Closes #712